### PR TITLE
Don't run BiocCheck in GHA

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -176,9 +176,8 @@ jobs:
           remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
 
           ## For running the checks
-          message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
+          message(paste('****', Sys.time(), 'installing rcmdcheck ****'))
           remotes::install_cran("rcmdcheck")
-          BiocManager::install("BiocCheck")
         shell: Rscript {0}
 
       - name: Install BiocGenerics
@@ -228,16 +227,6 @@ jobs:
         if:  env.has_RUnit == 'true'
         run: |
           BiocGenerics:::testPackage()
-        shell: Rscript {0}
-
-      - name: Run BiocCheck
-        run: |
-          BiocCheck::BiocCheck(
-              dir('check', 'tar.gz$', full.names = TRUE),
-              `quit-with-status` = TRUE,
-              `no-check-R-ver` = TRUE,
-              `no-check-bioc-help` = TRUE
-          )
         shell: Rscript {0}
 
       - name: Test coverage


### PR DESCRIPTION
It looks like the error is coming from a BiocCheck that we don't need since this won't be a Bioconductor package.